### PR TITLE
Expand backtest four factors defaults

### DIFF
--- a/nba_data/asof_fetchers.py
+++ b/nba_data/asof_fetchers.py
@@ -252,7 +252,11 @@ def _fetch_season_stats_asof(
             'efg_pct_season': row.get('EFG_PCT', 0),
             'tov_pct_season': row.get('TM_TOV_PCT', 0),
             'orb_pct_season': row.get('OREB_PCT', 0),
-            'ft_fga_season': row.get('FTA_RATE', 0),
+            'fta_rate_season': row.get('FTA_RATE', 0),
+            'opp_efg_pct_season': row.get('OPP_EFG_PCT', 0),
+            'opp_tov_pct_season': row.get('OPP_TOV_PCT', 0),
+            'opp_oreb_pct_season': row.get('OPP_OREB_PCT', 0),
+            'opp_fta_rate_season': row.get('OPP_FTA_RATE', 0),
         }
     elif measure_type == 'Misc':
         return {


### PR DESCRIPTION
## Summary
- supply complete four-factor data for backtest conversions with sensible league-average fallbacks
- extend as-of NBA fetcher to return opponent four-factor season metrics for compatibility

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d427bf5d68832db98f0c0971aa26e4